### PR TITLE
Allow a deal to be updated

### DIFF
--- a/app/model/business.go
+++ b/app/model/business.go
@@ -35,7 +35,6 @@ type BusinessUser struct {
 		Business_name *string            `json:"business_name"`
 		Address 			*Address           `json:"address" bson:"address"`
 		Location			*Location					 `json:"location" bson:"location"`
-		Deals 				[]*Deal	    			 `json:"deal"`	
 		Description	  *string						 `json:"description"`	
 }
 
@@ -54,7 +53,7 @@ type BusinessUserWrapper struct {
 }
 
 // newUser sets up a frontend appropriate [model.User]
-func NewBusinessUser(business *BusinessUser) *BusinessUserWrapper {
+func NewBusinessUser(business *BusinessUser, deals []*Deal) *BusinessUserWrapper {
 	return &BusinessUserWrapper{
 		First_name:      business.First_name,
 		Last_name:       business.Last_name,
@@ -63,7 +62,7 @@ func NewBusinessUser(business *BusinessUser) *BusinessUserWrapper {
 		Business_name:   business.Business_name,
 		Address:			   business.Address,
 		Location:				 business.Location,
-		Deals: 					 business.Deals,
+		Deals: 					 deals,
 		Description:     business.Description,
 	}
 }

--- a/app/model/deal.go
+++ b/app/model/deal.go
@@ -7,7 +7,8 @@ import (
 )
 
 type Deal struct {
-	ID          primitive.ObjectID `json:"id" bson:"_id"`
+	ID          primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Business_id primitive.ObjectID `json:"business_id" bson:"business_id"`
 	Name        *string            `json:"name"`
 	Start_time  *time.Time         `json:"start_time" bson:"start_time,omitempty"`
 	End_time    *time.Time         `json:"end_time" bson:"end_time,omitempty"`
@@ -15,4 +16,4 @@ type Deal struct {
 	Start_date  *time.Time         `json:"start_date" bson:"start_date,omitempty"`
 	End_date  *time.Time         	 `json:"end_date" bson:"end_date,omitempty"`
 	Description *string            `json:"description" bson:"description,omitempty"`
-}
+} 

--- a/app/model/requests/business.go
+++ b/app/model/requests/business.go
@@ -18,7 +18,6 @@ type Business struct {
 	Address 			*model.Address     `json:"address"`
 	Latitude			*float64					 `json:"latitude"`
 	Longitude			*float64					 `json:"longitude"`
-	Deals 				[]*model.Deal	     `json:"deal"`	
 	Description	  *string						 `json:"description"`	
 }
 
@@ -41,7 +40,6 @@ func NewBusinessUser(b Business) *model.BusinessUser {
 		Token:			 		 b.Token,
 		Refresh_token:   b.Refresh_token,
 		Business_name:   b.Business_name,
-		Deals: 					 b.Deals,
 		Description:     b.Description,
 		Password:				 b.Password,
 		Email: 					 b.Email,

--- a/app/model/requests/deal.go
+++ b/app/model/requests/deal.go
@@ -8,7 +8,8 @@ import (
 )
 
 type Deal struct {
-	ID          primitive.ObjectID `json:"id"`
+	ID          primitive.ObjectID `json:"id,omitempty"`
+	Business_id primitive.ObjectID `json:"business_id" bson:"business_id"`
 	Name        *string            `json:"name"`
 	Start_time  *time.Time         `json:"start_time"`
 	End_time    *time.Time         `json:"end_time"`
@@ -32,6 +33,7 @@ func ValidateDealStruct(d *Deal) error {
 func NewDeal(d Deal) *model.Deal {
 	return &model.Deal{
 		ID: 					d.ID,
+		Business_id:  d.Business_id,
 		Name:      		d.Name,
 		Start_time:		d.Start_time,
 		End_time:   	d.End_time,

--- a/app/model/requests/deal.go
+++ b/app/model/requests/deal.go
@@ -9,7 +9,7 @@ import (
 
 type Deal struct {
 	ID          primitive.ObjectID `json:"id,omitempty"`
-	Business_id primitive.ObjectID `json:"business_id" bson:"business_id"`
+	Business_id primitive.ObjectID `json:"business_id,omitempty" bson:"business_id,omitempty"`
 	Name        *string            `json:"name"`
 	Start_time  *time.Time         `json:"start_time"`
 	End_time    *time.Time         `json:"end_time"`

--- a/app/router/handlers/deals.go
+++ b/app/router/handlers/deals.go
@@ -1,10 +1,10 @@
 package handlers
 
 import (
+	"fmt"
 		"encoding/json"
     "context"
 		"log"
-		"fmt"
 
     "net/http"
 		"time"
@@ -15,12 +15,14 @@ import (
 		"github.com/CoffeeHausGames/whir-server/app/model"
 		requests "github.com/CoffeeHausGames/whir-server/app/model/requests"
 
+		"go.mongodb.org/mongo-driver/mongo"
     "go.mongodb.org/mongo-driver/bson"
     "go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 
-// Chat-GPTs attempt to make a Deal handler, help me :'(
+// Function to add a deal for the authenticated business user
+//I need to edit the below method to use the new database methods and store the deals in its own collection with the business ID as a foreign key
 	
 func (env *HandlerEnv) AddDeal(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		var ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
@@ -28,6 +30,7 @@ func (env *HandlerEnv) AddDeal(w http.ResponseWriter, r *http.Request, _ httprou
 
 		claims := r.Context().Value("claims").(*auth.SignedDetails)
 		body := r.Context().Value("body").(string)
+
 
     // Parse the request body to get building placement data
     // Unmarshal the URL-decoded JSON data into the placementData struct
@@ -47,66 +50,155 @@ func (env *HandlerEnv) AddDeal(w http.ResponseWriter, r *http.Request, _ httprou
 		}
 		
 		// Convert the hexadecimal string to an ObjectID
-		fmt.Println(claims.Uid)
 		objectID, err := primitive.ObjectIDFromHex(claims.Uid)
 		if err != nil {
 				// Handle the error if the hex string is not a valid ObjectID
 				panic(err)
 		}
-
+		fmt.Println(objectID)
+		dealData.Business_id = objectID
 		deal := requests.NewDeal(dealData)
 
-		currBusiness := new(model.BusinessUser)
-		var businessCollection model.Collection = env.database.GetBusinesses()
-		err = businessCollection.FindOne(currBusiness, ctx, bson.M{"_id": objectID})
-
-		currBusiness.Deals = append(currBusiness.Deals, deal)
-
-    filter := bson.M{"_id": objectID} // Modify this filter according to your user ID format
-		update := bson.M{"$set": bson.M{"deals": currBusiness.Deals}}
-
-    _, err = businessCollection.UpdateOne(ctx, filter, update)
+    dealCollection := env.database.GetDeals()
+    InsertedID, err := dealCollection.InsertOne(ctx, deal)
     if err != nil {
         log.Println(err)
-        WriteErrorResponse(w, http.StatusInternalServerError, "Failed to update user deals")
+        WriteErrorResponse(w, http.StatusInternalServerError, "Failed to insert deal")
         return
     }
+		deal.ID = InsertedID
 
-    WriteSuccessResponse(w, currBusiness)
+    WriteSuccessResponse(w, deal)
 }
+// TODO remove deals from businessUser model stored in bson and have it retrieve all the deals and return them from deal collection
 
-// What do we think about this?
 // Function to get deals for the authenticated business user
 func (env *HandlerEnv) GetSignedInBusinessDeals(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	// Extract the authenticated user's ID from the context
 	claims := r.Context().Value("claims").(*auth.SignedDetails)
 	userID, err := primitive.ObjectIDFromHex(claims.Uid)
 	if err != nil {
-		WriteErrorResponse(w, http.StatusInternalServerError, "Error parsing user ID")
-		return
+			WriteErrorResponse(w, http.StatusInternalServerError, "Error parsing user ID")
+			return
 	}
 
 	var ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	// Assuming that the "business" collection contains the business users
-	var businessCollection model.Collection = env.database.GetBusinesses()
+	dealCollection := env.database.GetDeals()
 
-	// Create a query to find the business user by ID
-	query := bson.M{"_id": userID}
+	query := bson.M{"business_id": userID}
 
-	// Perform the query to find the business user
-	foundUser := new(model.BusinessUser)
-	err = businessCollection.FindOne(foundUser, ctx, query)
+	cursor, err := dealCollection.Find(ctx, query)
 	if err != nil {
-		WriteErrorResponse(w, http.StatusNotFound, "Business user not found")
-		return
+			WriteErrorResponse(w, http.StatusInternalServerError, "Error finding deals")
+			return
 	}
 
-	// Extract the deals from the found business user
-	deals := foundUser.Deals
+	deals := GetMultipleDeals(cursor)
 
-	// Return the deals as the response
 	WriteSuccessResponse(w, deals)
 }
 
+// function to update deals for the authenticated user
+func (env *HandlerEnv) UpdateDeal(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	claims := r.Context().Value("claims").(*auth.SignedDetails)
+	body := r.Context().Value("body").(string)
+
+	var dealData requests.Deal
+	err := json.Unmarshal([]byte(body), &dealData)
+	if err != nil {
+			WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+	}
+
+	err = requests.ValidateDealStruct(&dealData)
+	if err != nil {
+			WriteErrorResponse(w, http.StatusUnprocessableEntity, err.Error())
+			return
+	}
+
+	userID, err := primitive.ObjectIDFromHex(claims.Uid)
+	if err != nil {
+			WriteErrorResponse(w, http.StatusInternalServerError, "Error parsing user ID")
+			return
+	}
+
+	dealCollection := env.database.GetDeals()
+	deal := requests.NewDeal(dealData)
+
+	query := bson.M{"_id": deal.ID, "business_id": userID}
+
+	update := bson.M{
+			"$set": deal,
+	}
+
+	_, err = dealCollection.UpdateOne(ctx, query, update)
+	if err != nil {
+			WriteErrorResponse(w, http.StatusInternalServerError, "Failed to update deal")
+			return
+	}
+
+	WriteSuccessResponse(w, deal)
+}
+
+// // Function to update a deal for the authenticated business user
+// func (env *HandlerEnv) UpdateDeal(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+// 	var ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+// 	defer cancel()
+
+// 	claims := r.Context().Value("claims").(*auth.SignedDetails)
+// 	body := r.Context().Value("body").(string)
+
+// 	// Need to retrieve the deal that is being updated from the body
+// 	var dealData requests.Deal
+// 	err := json.Unmarshal([]byte(body), &dealData)
+// 	if err != nil {
+// 			// Handle JSON decoding error
+// 			WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+// 			return
+// 	}
+
+// 	err = requests.ValidateDealStruct(&dealData)
+// 	if err != nil {
+// 			// Handle JSON decoding error
+// 			WriteErrorResponse(w, http.StatusUnprocessableEntity, err.Error())
+// 			return
+// 	}
+
+// 	// Convert the hexadecimal string to an ObjectID
+// 	objectID, err := primitive.ObjectIDFromHex(claims.Uid)
+// 	if err != nil {
+// 			// Handle the error if the hex string is not a valid ObjectID
+// 			WriteErrorResponse(w, http.StatusNotFound, "Business user not found")
+// 	}
+
+// 	// Assuming that the "business" collection contains the business users
+// 	var businessCollection model.Collection = env.database.GetBusinesses()
+
+// 	// Create a query to find the business user by ID
+// 	query := bson.M{"_id": objectID}
+
+
+// }
+
+// Function to retrieve multiple businesses near a location
+func GetMultipleDeals(cursor *mongo.Cursor) []model.Deal{
+
+	var deals []model.Deal
+	// Iterate through the cursor and decode each document into a Businesses struct.
+	for cursor.Next(context.Background()) {
+		var deal model.Deal
+
+		// Decode the current document into the Businesses struct.
+		if err := cursor.Decode(&deal); err != nil {
+				log.Fatal(err)
+		}
+
+		// Append the decoded struct to the slice.
+		deals = append(deals, deal)
+}
+return deals
+}

--- a/app/router/handlers/deals.go
+++ b/app/router/handlers/deals.go
@@ -128,6 +128,7 @@ func (env *HandlerEnv) UpdateDeal(w http.ResponseWriter, r *http.Request, _ http
 
 	dealCollection := env.database.GetDeals()
 	deal := requests.NewDeal(dealData)
+	deal.Business_id = userID
 
 	query := bson.M{"_id": deal.ID, "business_id": userID}
 

--- a/app/router/routes.go
+++ b/app/router/routes.go
@@ -17,10 +17,11 @@ func GetRouter(db *database.Database) http.Handler {
 	router.POST("/business/signup", middleware.UrlDecode(EnvHandler.BusinessSignUp))
 	router.POST("/users/login", middleware.UrlDecode(EnvHandler.Login))
 	router.POST("/business/login", middleware.UrlDecode(EnvHandler.BusinessLogin))
-	router.GET("/token", middleware.UrlDecode(EnvHandler.TokenRefresh))
+	router.GET("/token", EnvHandler.TokenRefresh)
 	router.POST("/business", middleware.UrlDecode(EnvHandler.GetBusiness))
 	router.POST("/business/deal", EnvHandler.BusinessAuthentication(middleware.UrlDecode(EnvHandler.AddDeal)))
-	router.GET("/business/deal", EnvHandler.BusinessAuthentication(middleware.UrlDecode(EnvHandler.GetSignedInBusinessDeals)))
+	router.GET("/business/deal", EnvHandler.BusinessAuthentication(EnvHandler.GetSignedInBusinessDeals))
+	router.PUT("/business/deal", EnvHandler.BusinessAuthentication(middleware.UrlDecode(EnvHandler.UpdateDeal)))
 
 	
 	

--- a/app/server/database/database.go
+++ b/app/server/database/database.go
@@ -73,16 +73,23 @@ func (d *Database) GetCollection(c string) model.Collection{
 	return GetMongoCollection(d.client.Database(d.databaseName).Collection(c))
 }
 
-//	GetUsers gets the user collection from the mongo database with name c
+//	GetUsers gets the user collection from the mongo database
 //	returns the users collection
 func (d *Database) GetUsers() model.Collection{
 	log.Println("Retrieving Users collection")
 	return GetMongoCollection(d.client.Database(d.databaseName).Collection("users"))
 }
 
-//	GetBusinesses gets the user collection from the mongo database with name c
-//	returns the users collection
+//	GetBusinesses gets the businesses collection from the mongo database
+//	returns the businesses collection
 func (d *Database) GetBusinesses() model.Collection{
 	log.Println("Retrieving Users collection")
 	return GetMongoCollection(d.client.Database(d.databaseName).Collection("businesses"))
+}
+
+//	GetDeals gets the deals collection from the mongo database
+//	returns the deals collection
+func (d *Database) GetDeals() model.Collection{
+	log.Println("Retrieving Users collection")
+	return GetMongoCollection(d.client.Database(d.databaseName).Collection("deals"))
 }

--- a/env/.env
+++ b/env/.env
@@ -1,3 +1,6 @@
 PORT=4444
+mac:
+MONGODB_URL="mongodb+srv://devtesting1:devtesting1@cluster0.j4x0atl.mongodb.net/?retryWrites=true&w=majority"
+windows:
 MONGODB_URL=mongodb+srv://devtesting1:devtesting1@cluster0.j4x0atl.mongodb.net/?retryWrites=true^&w=majority
 MONGODB_NAME=whir_test


### PR DESCRIPTION
the get deals now returns all the deals for the business instead of the business user(can change it back if needed) just makes sense to not send more information than needed

Also can update a deal now but you need the ID of the deal and Authorization header to update it 
PUT http://localhost:4444/business/deal
{
  "id": "65508148d7ac2c6758d3c669",
  "name": "Deal Example7",
  "start_time": "2023-11-09T12:34:56Z",
  "end_time": "2023-11-09T14:30:00Z",
  "day_of_week": "Monday",
  "start_date": "2023-11-09T14:30:00Z",
  "description": "Sample deal description"
}