### PR TITLE
Create a route and logic to pin and unpin deals for a business

### DIFF
--- a/app/helpers/helpers.go
+++ b/app/helpers/helpers.go
@@ -1,0 +1,14 @@
+package helpers
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func Contains(slice []*primitive.ObjectID, item *primitive.ObjectID) bool {
+	for _, a := range slice {
+			if a.Hex() == item.Hex() {
+					return true
+			}
+	}
+	return false
+}

--- a/app/router/handlers/deals.go
+++ b/app/router/handlers/deals.go
@@ -44,7 +44,7 @@ func (env *HandlerEnv) AddDeal(w http.ResponseWriter, r *http.Request, _ httprou
 				// Handle the error if the hex string is not a valid ObjectID
 				panic(err)
 		}
-		fmt.Println(objectID)
+
 		dealData.Business_id = objectID
 		deal := requests.NewDeal(dealData)
 

--- a/app/router/routes.go
+++ b/app/router/routes.go
@@ -33,6 +33,8 @@ func GetRouter(db *database.Database) http.Handler {
 	router.GET(version+"/business/profile", EnvHandler.BusinessAuthentication(EnvHandler.GetLoggedInBusiness))
 	router.PUT(version+"/business/profile", EnvHandler.BusinessAuthentication(middleware.UrlDecode(EnvHandler.UpdateBusinessInfo)))
 	router.PUT(version+"/business/deal", EnvHandler.BusinessAuthentication(middleware.UrlDecode(EnvHandler.UpdateDeal)))
+	router.PUT(version+"/business/deal/pin", EnvHandler.BusinessAuthentication(middleware.UrlDecode(EnvHandler.PinDeal)))
+	router.PUT(version+"/business/deal/unpin", EnvHandler.BusinessAuthentication(middleware.UrlDecode(EnvHandler.UnpinDeal)))
 	router.DELETE(version+"/business/deal", EnvHandler.BusinessAuthentication(middleware.UrlDecode(EnvHandler.DeleteDeal)))
 	router.DELETE(version+"/business/deals", EnvHandler.BusinessAuthentication(middleware.UrlDecode(EnvHandler.DeleteMultipleDeals)))
 


### PR DESCRIPTION
This PR is to create a route and the logic for businesses to be able to unpin and pin a deal. Currently a business can only pin 3 deals at a time.

Adds a PinnedDeals array of IDs to the Business model. Allows a client to retrieve the PinnedDeals when they retrieve the business info of the business

Endpoints:
PIN a deal:
PUT http://localhost:4444/v1/business/deal/pin
     {
        "ID": "6596515192743f92eff181d6"
    }

UNPIN a deal:
PUT http://localhost:4444/v1/business/deal/unpin
     {
        "ID": "6596515192743f92eff181d6"
    }

REQUIRES AUTH HEADER OR COOKIES FOR AN AUTHENTICATED BUSINESS